### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -44,6 +44,18 @@ class ItemsController < ApplicationController
 
   def edit
     @item = Item.find(params[:id])
+    # ここからセッションに保存された入力値を復元のための記述
+    if session[:item_edit_params]
+      @item.assign_attributes(session[:item_edit_params])
+      session[:item_edit_errors]&.each do |attr, messages|
+        messages.each do |msg|
+          @item.errors.add(attr, msg)
+        end
+      end
+      session.delete(:item_edit_params)
+      session.delete(:item_edit_errors)
+    end
+    # ここからセッションに保存された入力値を復元のための記述
   end
 
   def update
@@ -51,7 +63,9 @@ class ItemsController < ApplicationController
     if @item.update(item_params)
       redirect_to item_path(@item)
     else
-      render :edit
+      session[:item_edit_params] = item_params.to_h
+      session[:item_edit_errors] = @item.errors.messages
+      redirect_to edit_item_path(@item)
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit, :update]
   before_action :move_to_index, only: [:edit, :update]
+  before_action :set_item, only: [:show, :edit, :update]
 
   def index
     @items = Item.includes(:user).order(created_at: :desc)
@@ -39,11 +40,9 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def edit
-    @item = Item.find(params[:id])
     # ここからセッションに保存された入力値を復元のための記述
     return unless session[:item_edit_params]
 
@@ -55,12 +54,11 @@ class ItemsController < ApplicationController
     end
     session.delete(:item_edit_params)
     session.delete(:item_edit_errors)
-
-    # ここからセッションに保存された入力値を復元のための記述
+    # ここまでセッションに保存された入力値を復元のための記述
   end
 
   def update
-    @item = Item.find(params[:id])
+    # ここからセッションに保存された入力値を復元のための記述
     if @item.update(item_params)
       redirect_to item_path(@item)
     else
@@ -68,6 +66,7 @@ class ItemsController < ApplicationController
       session[:item_edit_errors] = @item.errors.messages
       redirect_to edit_item_path(@item)
     end
+    # ここまでセッションに保存された入力値を復元のための記述
   end
 
   private
@@ -77,6 +76,10 @@ class ItemsController < ApplicationController
     return if current_user == @item.user
 
     redirect_to root_path
+  end
+
+  def set_item
+    @item = Item.find(params[:id])
   end
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
 
   def index
     @items = Item.includes(:user).order(created_at: :desc)
@@ -39,6 +39,19 @@ class ItemsController < ApplicationController
 
   def show
     @item = Item.find(params[:id])
+  end
+
+  def edit
+    @item = Item.find(params[:id])
+  end
+
+  def update
+    @item = Item.find(params[:id])
+    if @item.update(item_params)
+      redirect_to item_path(@item)
+    else
+      render :edit
+    end
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,8 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit, :update]
-  before_action :move_to_index, only: [:edit, :update]
   before_action :set_item, only: [:show, :edit, :update]
+  before_action :move_to_index, only: [:edit, :update]
+
 
   def index
     @items = Item.includes(:user).order(created_at: :desc)
@@ -9,21 +10,6 @@ class ItemsController < ApplicationController
 
   def new
     @item = Item.new
-    # ここからセッションに保存された入力値を復元のための記述
-    if session[:item_params]
-      @item = Item.new(session[:item_params])
-      # エラー情報も復元
-      session[:item_errors]&.each do |attr, messages|
-        messages.each do |msg|
-          @item.errors.add(attr, msg)
-        end
-      end
-      session.delete(:item_params)
-      session.delete(:item_errors)
-    else
-      @item = Item.new
-    end
-    # ここまでセッションに保存された入力値を復元のための記述
   end
 
   def create
@@ -32,10 +18,7 @@ class ItemsController < ApplicationController
     if @item.save
       redirect_to root_path
     else
-      # 入力値・エラーをセッションに保存してリダイレクト
-      session[:item_params] = item_params.to_h
-      session[:item_errors] = @item.errors.messages
-      redirect_to new_item_path
+      render :new, status: :unprocessable_entity
     end
   end
 
@@ -43,36 +26,19 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    # ここからセッションに保存された入力値を復元のための記述
-    return unless session[:item_edit_params]
-
-    @item.assign_attributes(session[:item_edit_params])
-    session[:item_edit_errors]&.each do |attr, messages|
-      messages.each do |msg|
-        @item.errors.add(attr, msg)
-      end
-    end
-    session.delete(:item_edit_params)
-    session.delete(:item_edit_errors)
-    # ここまでセッションに保存された入力値を復元のための記述
   end
 
   def update
-    # ここからセッションに保存された入力値を復元のための記述
     if @item.update(item_params)
       redirect_to item_path(@item)
     else
-      session[:item_edit_params] = item_params.to_h
-      session[:item_edit_errors] = @item.errors.messages
-      redirect_to edit_item_path(@item)
+      render :edit, status: :unprocessable_entity
     end
-    # ここまでセッションに保存された入力値を復元のための記述
   end
 
   private
 
   def move_to_index
-    @item = Item.find(params[:id])
     return if current_user == @item.user
 
     redirect_to root_path

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -45,16 +45,17 @@ class ItemsController < ApplicationController
   def edit
     @item = Item.find(params[:id])
     # ここからセッションに保存された入力値を復元のための記述
-    if session[:item_edit_params]
-      @item.assign_attributes(session[:item_edit_params])
-      session[:item_edit_errors]&.each do |attr, messages|
-        messages.each do |msg|
-          @item.errors.add(attr, msg)
-        end
+    return unless session[:item_edit_params]
+
+    @item.assign_attributes(session[:item_edit_params])
+    session[:item_edit_errors]&.each do |attr, messages|
+      messages.each do |msg|
+        @item.errors.add(attr, msg)
       end
-      session.delete(:item_edit_params)
-      session.delete(:item_edit_errors)
     end
+    session.delete(:item_edit_params)
+    session.delete(:item_edit_errors)
+
     # ここからセッションに保存された入力値を復元のための記述
   end
 
@@ -73,9 +74,9 @@ class ItemsController < ApplicationController
 
   def move_to_index
     @item = Item.find(params[:id])
-    unless current_user == @item.user
-      redirect_to root_path
-    end
+    return if current_user == @item.user
+
+    redirect_to root_path
   end
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit, :update]
+  before_action :move_to_index, only: [:edit, :update]
 
   def index
     @items = Item.includes(:user).order(created_at: :desc)
@@ -55,6 +56,13 @@ class ItemsController < ApplicationController
   end
 
   private
+
+  def move_to_index
+    @item = Item.find(params[:id])
+    unless current_user == @item.user
+      redirect_to root_path
+    end
+  end
 
   def item_params
     params.require(:item).permit(:name, :description, :price, :category_id, :condition_id, :shipping_payer_id, :duration_id,

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -140,7 +140,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%= link_to 'もどる', item_path(@item), class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,11 +7,10 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @item, local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%# エラーメッセージ表示 %>
+    <%= render 'shared/error_messages', model: f.object %>
 
     <%# 商品画像 %>
     <div class="img-upload">
@@ -23,7 +22,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /商品画像 %>
@@ -33,13 +32,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :description, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）", rows:"7", maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +51,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {prompt: '---'}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:condition_id, Condition.all, :id, :name, {prompt: '---'}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +72,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:shipping_payer_id, ShippingPayer.all, :id, :name, {prompt: '---'}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {prompt: '---'}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:duration_id, Duration.all, :id, :name, {prompt: '---'}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +100,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -22,7 +22,7 @@
     </div>
     <% if user_signed_in? %>
       <% if current_user == @item.user %>
-        <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+        <%= link_to "商品の編集", edit_item_path(@item), class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
       <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  resources :items, only: [:index, :new, :create, :show]
+  resources :items, only: [:index, :new, :create, :show, :edit, :update]
   root to: 'items#index'
   devise_for :users
 end


### PR DESCRIPTION
# What
出品した商品の情報を編集するための商品情報編集機能を実装しました。

以下は実装した機能の動作確認動画となります。
- [ログイン状態の出品者は、商品情報編集ページに遷移できる動画](https://gyazo.com/d0d8b50ff1cd8fee886374b0a4ed5ae7)
- [必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画](https://gyazo.com/aeec22cedb01de39ab95f3c0c41cf4f9)
- [入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画](https://gyazo.com/6ba3cead44da257ab07eba7416c3d369)
- [何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画](https://gyazo.com/cfc1b9e3ea9d018090706f02231645f3)
- [ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画](https://gyazo.com/0bc3040016995222231545f45f49f918)
- [ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画](https://gyazo.com/624e174534afb1ad3ef3fe65fae2e325)
- [商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）](https://gyazo.com/66e2a6a1a061d2bf07ca997a89478391)

# Why
出品したあとの商品情報を編集する機能実装のため
